### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: android
 jdk: oraclejdk8
 android:
   components:
-    - build-tools-20.0.0
-    - android-L
-    - sys-img-armeabi-v7a-android-tv-l
-    - add-on
-    - extra
-  licenses:
-    - 'android-sdk-preview-license-52d11cd2'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
+    - tools
+    - build-tools-25.0.2
+    - android-25
+    - extra-android-m2repository
+
+before_install:
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"


### PR DESCRIPTION
As per https://github.com/travis-ci/travis-ci/issues/6617

O _build_ continua quebrado, mas agora é por falha nos testes mesmo. O erro anterior,

```
> You have not accepted the license agreements of the following SDK components:
  [Android SDK Build-Tools 25.0.2, Android SDK Platform 25].
```
se encontra resolvido.